### PR TITLE
Add Streamlit interface to document indexer

### DIFF
--- a/rag/document_indexer_streamlit.py
+++ b/rag/document_indexer_streamlit.py
@@ -1,0 +1,35 @@
+import streamlit as st
+import os
+import pickle
+from document_indexer import chunk_document, HuggingFaceEmbeddings, FAISS
+
+def streamlit_interface():
+    st.title("Document Indexer")
+
+    doc_path = st.text_input("Path of the documents:", value="documents")
+    chunk_size = st.number_input("Size of the chunk:", value=64, step=1)
+    chunk_step = st.number_input("Step size of the chunk:", value=64, step=1)
+    output_path = st.text_input("Path of the output:", value="knowledge")
+
+    if st.button("Index Documents"):
+        try:
+            file_count, texts, metadata_list, chunk_id_to_index = chunk_document(
+                doc_path=doc_path,
+                chunk_size=chunk_size,
+                chunk_step=chunk_step,
+            )
+            embeddings = HuggingFaceEmbeddings(model_name="all-MiniLM-L6-v2")
+            vectorstore = FAISS.from_texts(
+                texts=texts,
+                metadatas=metadata_list,
+                embedding=embeddings,
+            )
+            vectorstore.save_local(folder_path=output_path)
+            with open(os.path.join(output_path, "chunk_id_to_index.pkl"), "wb") as f:
+                pickle.dump(chunk_id_to_index, f)
+            st.success(f"Successfully indexed {file_count} documents. Saved vectorstore to {output_path}")
+        except Exception as e:
+            st.error(f"An error occurred: {str(e)}")
+
+if __name__ == "__main__":
+    streamlit_interface()


### PR DESCRIPTION
Related to #7

Introduces a Streamlit interface for the document_indexer.py script, enabling users to run the script as a web app with a user-friendly interface.

- **Adds a new file** `rag/document_indexer_streamlit.py` which acts as a wrapper around the original `document_indexer.py` script, keeping the original script untouched as per the issue's request.
- **Implements Streamlit UI elements** for user inputs, including text inputs for document path and output path, and number inputs for chunk size and step size, aligning with the specified requirements.
- **Integrates document indexing functionality** within the Streamlit interface, allowing users to index documents by entering parameters through the web interface and initiating the indexing process with a button click.
- **Displays success or error messages** in the Streamlit app, providing feedback on the indexing process outcome, including the number of documents indexed and the location of the saved vectorstore, or displaying errors if encountered.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/madtank/autogenstudio-skills/issues/7?shareId=1b3d01be-c059-4b5f-bcff-953f46d08e47).